### PR TITLE
this.blockingNeutral can be null

### DIFF
--- a/src/main/java/bwem/ChokePointImpl.java
+++ b/src/main/java/bwem/ChokePointImpl.java
@@ -243,7 +243,7 @@ public class ChokePointImpl implements ChokePoint {
             throw new IllegalStateException();
         }
 
-        if (this.blockingNeutral.equals(pBlocking)) {
+        if (this.blockingNeutral == pBlocking) {
             // Ensures that in the case where several neutrals are stacked, blockingNeutral points to the
             // bottom one:
             this.blockingNeutral =

--- a/src/main/java/bwem/ChokePointImpl.java
+++ b/src/main/java/bwem/ChokePointImpl.java
@@ -243,7 +243,7 @@ public class ChokePointImpl implements ChokePoint {
             throw new IllegalStateException();
         }
 
-        if (this.blockingNeutral == pBlocking) {
+        if (pBlocking.equals(this.blockingNeutral)) {
             // Ensures that in the case where several neutrals are stacked, blockingNeutral points to the
             // bottom one:
             this.blockingNeutral =


### PR DESCRIPTION
I think changing .equals() to == will fix a possible crash at this location. We know that pBlocking is not null because the preceding line would have thrown IllegalStateException.