### PR TITLE
Map strings without encoding/decoding them

### DIFF
--- a/src/main/java/bwapi/WrappedBuffer.java
+++ b/src/main/java/bwapi/WrappedBuffer.java
@@ -14,9 +14,6 @@ import java.nio.charset.StandardCharsets;
  * Wrapper around ByteBuffer that makes use of sun.misc.Unsafe if available.
  */
 class WrappedBuffer {
-    private static final Charset charSet = StandardCharsets.ISO_8859_1;
-    private static final CharsetEncoder enc = charSet.newEncoder();
-
     private final ByteBuffer buffer;
     private final long address;
     private final Unsafe unsafe;
@@ -72,25 +69,26 @@ class WrappedBuffer {
     }
 
     String getString(final int offset, final int maxLen) {
-        buffer.position(offset);
-        ByteBuffer source = buffer.slice();
-        int rem = maxLen - 1;
-        while (source.get() != 0 && rem > 0) {
-            rem--;
+        char[] buf = new char[maxLen];
+        long pos = offset + address;
+        for (int i = 0; i < maxLen; i++) {
+            byte b = unsafe.getByte(pos);
+            if (b == 0) break;
+            buf[i] = (char) (b & 0xff);
+            pos++;
         }
-        if (rem > 0) {
-            source.position(source.position() - 1);
-        }
-        source.flip();
-        return charSet.decode(source).toString();
+        return new String(buf, 0, (int) (pos - offset - address));
     }
 
     void putString(final int offset, final int maxLen, final String string) {
         if (string.length() + 1 >= maxLen) {
             throw new StringIndexOutOfBoundsException();
         }
-        buffer.position(offset);
-        enc.encode(CharBuffer.wrap(string), buffer, true);
-        buffer.put((byte) 0);
+        long pos = offset + address;
+        for (int i = 0; i < string.length(); i++) {
+            unsafe.putByte(pos, (byte) string.charAt(i));
+            pos++;
+        }
+        unsafe.putByte(pos, (byte) 0);
     }
 }

--- a/src/test/java/bwapi/ClientDataBenchmark.java
+++ b/src/test/java/bwapi/ClientDataBenchmark.java
@@ -56,6 +56,14 @@ public class ClientDataBenchmark {
     }
 
     @Benchmark
+    @Measurement(iterations = 2, time = 2)
+    @Warmup(time = 2)
+    @Fork(2)
+    public void reference(Blackhole blackhole) {
+        blackhole.consume(0);
+    }
+
+    @Benchmark
     @OperationsPerInvocation(Client.MAX_COUNT)
     public int addUnitCommand(EmptyState s) {
         for (int i = 0; i < Client.MAX_COUNT; i++) {

--- a/src/test/java/bwapi/WrappedBufferTest.java
+++ b/src/test/java/bwapi/WrappedBufferTest.java
@@ -12,7 +12,7 @@ public class WrappedBufferTest {
     @Test
     public void shouldGetAndSetStrings() {
         // GIVEN
-        String testString = "Test";
+        String testString = "@µöú";
         sut.putString(123, 100, testString);
 
         // WHEN
@@ -25,7 +25,7 @@ public class WrappedBufferTest {
     @Test
     public void shouldCutOffAtMaxLength() {
         // GIVEN
-        String testString = "Test";
+        String testString = "@µöú";
         sut.putString(123, 100, testString);
 
         // WHEN


### PR DESCRIPTION
Although Travis build-environment might differ per run, which would skew benchmark results a lot, I think comparing the op/s from this branch are to the base branch is still "ok":
This branch:
```
Benchmark                            Mode  Cnt          Score          Error  Units
ClientDataBenchmark.addString       thrpt    9    1221113.088 ±    26604.606  ops/s
ClientDataBenchmark.getString       thrpt    9     720786.947 ±    15406.933  ops/s
ClientDataBenchmark.reference       thrpt    4  373790491.499 ±  1494879.446  ops/s
```

develop branch:
```
Benchmark                            Mode  Cnt          Score         Error  Units
ClientDataBenchmark.addString       thrpt    9     577234.152 ±   29329.252  ops/s
ClientDataBenchmark.getString       thrpt    9     213828.911 ±    2650.206  ops/s
ClientDataBenchmark.reference       thrpt    4  373824888.150 ± 2797797.599  ops/s
```
