### PR TITLE
Allow quieting assertions via BWTA interface

### DIFF
--- a/src/main/java/bwem/BWMap.java
+++ b/src/main/java/bwem/BWMap.java
@@ -91,7 +91,7 @@ public abstract class BWMap {
         }
 
         if (atLeastOneFailed) {
-            asserter.throwIllegalStateException("At least one starting location was not assigned to a base.");
+            //asserter.throwIllegalStateException("At least one starting location was not assigned to a base.");
         }
     }
 

--- a/src/main/java/bwem/BWMap.java
+++ b/src/main/java/bwem/BWMap.java
@@ -91,7 +91,7 @@ public abstract class BWMap {
         }
 
         if (atLeastOneFailed) {
-            //asserter.throwIllegalStateException("At least one starting location was not assigned to a base.");
+            asserter.throwIllegalStateException("At least one starting location was not assigned to a base.");
         }
     }
 

--- a/src/main/java/bwta/BWTA.java
+++ b/src/main/java/bwta/BWTA.java
@@ -4,11 +4,10 @@ import bwapi.Game;
 import bwapi.Player;
 import bwapi.Position;
 import bwapi.TilePosition;
+import bwem.Area;
 import bwem.BWEM;
 import bwem.Base;
 import bwem.ChokePoint;
-
-import bwem.Area;
 
 import java.io.OutputStream;
 import java.util.*;
@@ -23,17 +22,29 @@ public class BWTA {
     private static List<Chokepoint> chokepoints;
     private static List<BaseLocation> baseLocations;
 
-    public static void readMap(final Game game) {
-        System.err.println("WARNING: this BWTA is fake and only translates BWTA calls to their respective BWEM calls. Please use BWEM directly if possible.");
-        bwem = new BWEM(game);
-    }
-
+    /**
+     * Extension to traditional BWTA interface for JBWAPI
+     * Exposes BWEM's setFailOnError(boolean) method for aggressively asserting errors.
+     *
+     * @param value Whether BWEM should throw an exception on assertion failure.
+     */
     public static void setFailOnError(final boolean value) {
         bwem.setFailOnError(value);
     }
 
+    /**
+     * Extension to traditional BWTA interface for JBWAPI
+     * Exposes BWEM's setFailOnErrorStream(OutputStream) method for specifying error log destination.
+     *
+     * @param stream Where to log BWEM errors.
+     */
     public static void setFailOnErrorStream(OutputStream stream) {
         bwem.setFailOutputStream(stream);
+    }
+
+    public static void readMap(final Game game) {
+        System.err.println("WARNING: this BWTA is fake and only translates BWTA calls to their respective BWEM calls. Please use BWEM directly if possible.");
+        bwem = new BWEM(game);
     }
 
     public static void analyze() {

--- a/src/main/java/bwta/BWTA.java
+++ b/src/main/java/bwta/BWTA.java
@@ -9,6 +9,8 @@ import bwem.Base;
 import bwem.ChokePoint;
 
 import bwem.Area;
+
+import java.io.OutputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -24,6 +26,14 @@ public class BWTA {
     public static void readMap(final Game game) {
         System.err.println("WARNING: this BWTA is fake and only translates BWTA calls to their respective BWEM calls. Please use BWEM directly if possible.");
         bwem = new BWEM(game);
+    }
+
+    public static void setFailOnError(final boolean value) {
+        bwem.setFailOnError(value);
+    }
+
+    public static void setFailOnErrorStream(OutputStream stream) {
+        bwem.setFailOutputStream(stream);
     }
 
     public static void analyze() {


### PR DESCRIPTION
**Original description** This assertion causes analysis to fail on Neo Aztec.

**Edited description** Exposing BWEM's assertion-silencing interface via the BWTA interface.